### PR TITLE
Revoke role mgmt from users

### DIFF
--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -62,7 +62,7 @@ REVOKE ALL ON FUNCTION ClassDB.isStudent(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isStudent(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 CREATE OR REPLACE FUNCTION ClassDB.isInstructor(userName ClassDB.IDNameDomain)
@@ -85,7 +85,7 @@ REVOKE ALL ON FUNCTION ClassDB.isInstructor(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isInstructor(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 CREATE OR REPLACE FUNCTION ClassDB.isDBManager(userName ClassDB.IDNameDomain)
@@ -108,7 +108,7 @@ REVOKE ALL ON FUNCTION ClassDB.isDBManager(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isDBManager(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -175,7 +175,7 @@ GRANT EXECUTE ON FUNCTION
    ClassDB.createStudent(ClassDB.IDNameDomain, ClassDB.RoleBase.FullName%Type,
                          ClassDB.IDNameDomain, ClassDB.RoleBase.ExtraInfo%Type,
                          BOOLEAN, BOOLEAN, VARCHAR(128))
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -215,7 +215,7 @@ REVOKE ALL ON FUNCTION ClassDB.revokeStudent(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.revokeStudent(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -253,7 +253,7 @@ REVOKE ALL ON FUNCTION
 GRANT EXECUTE ON FUNCTION
    ClassDB.dropStudent(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
                        ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -286,7 +286,7 @@ REVOKE ALL ON FUNCTION ClassDB.dropAllStudents(BOOLEAN, BOOLEAN, VARCHAR,
 
 GRANT EXECUTE ON FUNCTION ClassDB.dropAllStudents(BOOLEAN, BOOLEAN, VARCHAR,
                                                   ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -350,7 +350,7 @@ GRANT EXECUTE ON FUNCTION
                             ClassDB.IDNameDomain,
                             ClassDB.RoleBase.ExtraInfo%Type,
                             BOOLEAN, BOOLEAN, VARCHAR(128))
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -381,7 +381,7 @@ REVOKE ALL ON FUNCTION ClassDB.revokeInstructor(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.revokeInstructor(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -419,7 +419,7 @@ REVOKE ALL ON FUNCTION
 GRANT EXECUTE ON FUNCTION
    ClassDB.dropInstructor(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
                           ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -476,7 +476,7 @@ GRANT EXECUTE ON FUNCTION
                            ClassDB.IDNameDomain,
                            ClassDB.RoleBase.ExtraInfo%Type,
                            BOOLEAN, BOOLEAN, VARCHAR(128))
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -501,7 +501,7 @@ REVOKE ALL ON FUNCTION ClassDB.revokeDBManager(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.revokeDBManager(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -539,7 +539,7 @@ REVOKE ALL ON FUNCTION
 GRANT EXECUTE ON FUNCTION
    ClassDB.dropDBManager(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
                          ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -593,7 +593,7 @@ GRANT EXECUTE ON FUNCTION
    ClassDB.createTeam(ClassDB.IDNameDomain, ClassDB.RoleBase.FullName%Type,
                       ClassDB.IDNameDomain, ClassDB.RoleBase.ExtraInfo%Type,
                       BOOLEAN, BOOLEAN)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -627,7 +627,7 @@ ALTER FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.revokeTeam(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -665,7 +665,7 @@ REVOKE ALL ON FUNCTION
 GRANT EXECUTE ON FUNCTION
    ClassDB.dropTeam(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN, VARCHAR,
                     ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -698,7 +698,7 @@ REVOKE ALL ON FUNCTION
 GRANT EXECUTE ON FUNCTION
    ClassDB.dropAllTeams(BOOLEAN, BOOLEAN, VARCHAR,
                         ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -732,7 +732,7 @@ REVOKE ALL ON FUNCTION
 
 GRANT EXECUTE ON FUNCTION
    ClassDB.isTeamMember(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -803,7 +803,7 @@ REVOKE ALL ON FUNCTION
 
 GRANT EXECUTE ON FUNCTION
    ClassDB.addToTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -890,7 +890,7 @@ REVOKE ALL ON FUNCTION
 
 GRANT EXECUTE ON FUNCTION
    ClassDB.removeFromTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 
@@ -915,7 +915,7 @@ REVOKE ALL ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 COMMIT;

--- a/src/db/core/addClassDBRolesMgmtCore.sql
+++ b/src/db/core/addClassDBRolesMgmtCore.sql
@@ -803,7 +803,7 @@ REVOKE ALL ON FUNCTION
 
 GRANT EXECUTE ON FUNCTION
    ClassDB.addToTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
-   TO ClassDB_Admin;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -890,7 +890,7 @@ REVOKE ALL ON FUNCTION
 
 GRANT EXECUTE ON FUNCTION
    ClassDB.removeFromTeam(ClassDB.IDNameDomain, ClassDB.IDNameDomain)
-   TO ClassDB_Admin;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -915,7 +915,7 @@ REVOKE ALL ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.removeAllFromTeam(ClassDB.IDNameDomain)
-   TO ClassDB_Admin;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 COMMIT;

--- a/src/db/core/addClassDBRolesViewsCore.sql
+++ b/src/db/core/addClassDBRolesViewsCore.sql
@@ -86,7 +86,8 @@ ORDER BY UserName;
 
 ALTER VIEW ClassDB.User OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.User FROM PUBLIC;
-GRANT SELECT ON ClassDB.User TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.User 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -102,7 +103,8 @@ CREATE OR REPLACE VIEW ClassDB.Instructor AS
 
 ALTER VIEW ClassDB.Instructor OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.Instructor FROM PUBLIC;
-GRANT SELECT ON ClassDB.Instructor TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.Instructor 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -116,7 +118,8 @@ CREATE OR REPLACE VIEW ClassDB.Student AS
 
 ALTER VIEW ClassDB.Student OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.Student FROM PUBLIC;
-GRANT SELECT ON ClassDB.Student TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.Student 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -130,7 +133,8 @@ CREATE OR REPLACE VIEW ClassDB.DBManager AS
 
 ALTER VIEW ClassDB.DBManager OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.DBManager FROM PUBLIC;
-GRANT SELECT ON ClassDB.DBManager TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.DBManager 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Define a view to return Team members and thier respective team
@@ -145,7 +149,8 @@ CREATE OR REPLACE VIEW ClassDB.TeamMember AS
 
 ALTER VIEW ClassDB.TeamMember OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.User FROM PUBLIC;
-GRANT SELECT ON ClassDB.TeamMember TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.TeamMember 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Define a view to return known teams with thier RoleName, FullName, SchemaName,
@@ -167,7 +172,8 @@ CREATE OR REPLACE VIEW ClassDB.Team AS
 
 ALTER VIEW ClassDB.Team OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.Team FROM PUBLIC;
-GRANT SELECT ON ClassDB.Team TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.Team 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 COMMIT;

--- a/src/db/core/addHelpersCore.sql
+++ b/src/db/core/addHelpersCore.sql
@@ -389,7 +389,7 @@ ALTER FUNCTION ClassDB.listOwnedObjects(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.listOwnedObjects(ClassDB.IDNameDomain) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.listOwnedObjects(ClassDB.IDNameDomain)
-      TO ClassDB_Instructor, ClassDB_DBManager;
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Define a function to list all 'orphan' objects owned by ClassDB_Instructor and
@@ -435,7 +435,7 @@ ALTER FUNCTION ClassDB.listOrphanObjects(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.listOrphanObjects(ClassDB.IDNameDomain) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.listOrphanObjects(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Define a function to reassign ownership of an object. The executing user must
@@ -643,7 +643,7 @@ $$ LANGUAGE sql
 
 REVOKE ALL ON FUNCTION ClassDB.getSessionID() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getSessionID()
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 
 

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -113,10 +113,10 @@ REVOKE ALL PRIVILEGES ON ClassDB.RoleBase FROM PUBLIC;
 -- FullName and ExtraInfo are safe to edit after a record is created
 -- inserts and deletes are performed only in functions which run as ClassDB
 GRANT SELECT ON ClassDB.RoleBase
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 GRANT UPDATE (FullName, ExtraInfo) ON ClassDB.RoleBase
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -142,7 +142,7 @@ REVOKE ALL ON FUNCTION ClassDB.getSchemaName(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.getSchemaName(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -165,7 +165,7 @@ REVOKE ALL ON FUNCTION ClassDB.isRoleKnown(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isRoleKnown(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -186,7 +186,7 @@ ALTER FUNCTION ClassDB.isUser(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.isUser(ClassDB.IDNameDomain) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isUser(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -208,7 +208,7 @@ REVOKE ALL ON FUNCTION ClassDB.isTeam(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isTeam(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 
@@ -616,7 +616,7 @@ REVOKE ALL ON FUNCTION ClassDB.resetPassword(ClassDB.IDNameDomain)
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.resetPassword(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 COMMIT;

--- a/src/db/core/addRoleBaseMgmtCore.sql
+++ b/src/db/core/addRoleBaseMgmtCore.sql
@@ -116,7 +116,7 @@ GRANT SELECT ON ClassDB.RoleBase
    TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 GRANT UPDATE (FullName, ExtraInfo) ON ClassDB.RoleBase
-   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin;
 
 
 

--- a/src/db/core/addUserMgmtCore.sql
+++ b/src/db/core/addUserMgmtCore.sql
@@ -76,7 +76,8 @@ CREATE TABLE IF NOT EXISTS ClassDB.DDLActivity
 -- the code does something significantly different
 ALTER TABLE ClassDB.DDLActivity OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.DDLActivity FROM PUBLIC;
-GRANT SELECT ON ClassDB.DDLActivity TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT SELECT ON ClassDB.DDLActivity TO 
+   ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Define a function to upgrade table DDLActivity from v2.0 to v.21
@@ -147,7 +148,7 @@ CREATE TABLE IF NOT EXISTS ClassDB.ConnectionActivity
 ALTER TABLE ClassDB.ConnectionActivity OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.ConnectionActivity FROM PUBLIC;
 GRANT SELECT ON ClassDB.ConnectionActivity
-      TO ClassDB_Instructor, ClassDB_DBManager;
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 

--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -80,21 +80,14 @@ BEGIN
 
    --Let only app-specific roles connect to the DB
    -- no need for ClassDB to connect to the DB
-   EXECUTE format('GRANT CONNECT ON DATABASE %I TO ClassDB_Instructor, '
-                  'ClassDB_Student, ClassDB_DBManager', currentDB);
+   EXECUTE format('GRANT CONNECT ON DATABASE %I TO ClassDB_Admin, '
+                  'ClassDB_Instructor, ClassDB_Student, ClassDB_DBManager'
+                  , currentDB);
 
    --Allow ClassDB and ClassDB users to create schemas on the current database
-   EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Instructor,'
-                  ' ClassDB_DBManager, ClassDB_Student', currentDB);
-
-   --Grant ClassDB to the current user
-   -- allows altering privileges of objects, even after being owned by ClassDB
-
-   --The use of CURRENT_USER in a GRANT query is permitted only from pg9.5
-   -- Use dynamic SQL on all pg versions so the script compiles on pg9.4 and earlier
-   -- replace dynamic SQL with the commmented out query when pg9.4 is unsupported
-   --GRANT ClassDB TO CURRENT_USER;
-   EXECUTE FORMAT('GRANT ClassDB TO %s', CURRENT_USER);
+   EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Admin, '
+                  'ClassDB_Instructor, ClassDB_Student, ClassDB_DBManager'
+                  , currentDB);
 
 END
 $$;
@@ -104,11 +97,12 @@ $$;
 --Prevent users who are not instructors from modifying the public schema
 -- public schema contains objects and functions students can read
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
-GRANT CREATE ON SCHEMA public TO ClassDB_Instructor;
+GRANT CREATE ON SCHEMA public TO ClassDB_Admin, ClassDB_Instructor;
 
 --Create a schema to hold app's admin info and assign privileges on that schema
 CREATE SCHEMA IF NOT EXISTS classdb AUTHORIZATION ClassDB;
-GRANT USAGE ON SCHEMA classdb TO ClassDB_Instructor, ClassDB_DBManager;
+GRANT USAGE ON SCHEMA classdb 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 COMMIT;

--- a/src/db/reco/addConnectionActivityLoggingReco.sql
+++ b/src/db/reco/addConnectionActivityLoggingReco.sql
@@ -63,7 +63,7 @@ REVOKE ALL ON FUNCTION ClassDB.isConnectionLoggingEnabled()
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isConnectionLoggingEnabled()
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Helper function to check if server parameter logging_collector is set to 'on' or 'off'.
@@ -83,7 +83,7 @@ REVOKE ALL ON FUNCTION ClassDB.isLoggingCollectorEnabled()
    FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.isLoggingCollectorEnabled()
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Function to import log files between a starting date and the current date
@@ -257,6 +257,6 @@ $$ LANGUAGE plpgsql
 REVOKE ALL ON FUNCTION ClassDB.importConnectionLog(DATE) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION ClassDB.importConnectionLog(DATE)
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 COMMIT;

--- a/src/db/reco/addConnectionMgmtReco.sql
+++ b/src/db/reco/addConnectionMgmtReco.sql
@@ -64,7 +64,7 @@ REVOKE ALL ON FUNCTION
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION
    classdb.listUserConnections(VARCHAR(63))
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Kills a specific connection given a pid INT4
@@ -94,7 +94,7 @@ $$;
 REVOKE ALL ON FUNCTION classdb.killConnection(INT) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION classdb.killConnection(INT)
-TO ClassDB_Instructor, ClassDB_DBManager;
+TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 --Kills all open connections for a specific user
@@ -123,7 +123,7 @@ REVOKE ALL ON FUNCTION
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION
    classdb.killUserConnections(VARCHAR(63))
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 COMMIT;

--- a/src/db/reco/addDDLActivityLoggingReco.sql
+++ b/src/db/reco/addDDLActivityLoggingReco.sql
@@ -139,7 +139,7 @@ $$ LANGUAGE plpgsql
 -- permissions
 REVOKE ALL ON FUNCTION ClassDB.enableDDLActivityLogging() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.enableDDLActivityLogging()
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 CREATE OR REPLACE FUNCTION ClassDB.disableDDLActivityLogging()
 RETURNS VOID AS
@@ -153,6 +153,6 @@ $$ LANGUAGE plpgsql
 
 REVOKE ALL ON FUNCTION ClassDB.disableDDLActivityLogging() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.disableDDLActivityLogging()
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 COMMIT;

--- a/src/db/reco/addDisallowSchemaDropReco.sql
+++ b/src/db/reco/addDisallowSchemaDropReco.sql
@@ -82,7 +82,7 @@ $$ LANGUAGE sql
 
 REVOKE ALL ON FUNCTION ClassDB.disallowSchemaDrop() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.disallowSchemaDrop()
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 
 
@@ -95,7 +95,7 @@ $$ LANGUAGE sql
 
 REVOKE ALL ON FUNCTION ClassDB.allowSchemaDrop() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.allowSchemaDrop()
-   TO ClassDB_Instructor, ClassDB_DBManager, ClassDB;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager, ClassDB;
 
 
 
@@ -123,7 +123,7 @@ $$ LANGUAGE sql
 ALTER FUNCTION ClassDB.isSchemaDropAllowed() OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.isSchemaDropAllowed() FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.isSchemaDropAllowed()
-   TO ClassDB_Instructor, ClassDB_DBManager;
+   TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 COMMIT;

--- a/src/db/reco/addFrequentViewsReco.sql
+++ b/src/db/reco/addFrequentViewsReco.sql
@@ -94,7 +94,7 @@ CREATE OR REPLACE VIEW ClassDB.StudentTable AS
 
 ALTER VIEW ClassDB.StudentTable OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentTable FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentTable TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentTable TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -110,7 +110,7 @@ CREATE OR REPLACE VIEW ClassDB.StudentTableCount AS
 
 ALTER VIEW ClassDB.StudentTableCount OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentTableCount FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentTableCount TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentTableCount TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -144,7 +144,7 @@ ALTER FUNCTION ClassDB.getUserActivitySummary(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getUserActivitySummary(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getUserActivitySummary(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -174,7 +174,7 @@ ALTER FUNCTION ClassDB.getStudentActivitySummary(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getStudentActivitySummary(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getStudentActivitySummary(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -188,7 +188,8 @@ CREATE OR REPLACE VIEW ClassDB.StudentActivitySummary AS
 
 ALTER VIEW ClassDB.StudentActivitySummary OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentActivitySummary FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentActivitySummary TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentActivitySummary 
+      TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -216,7 +217,7 @@ ALTER FUNCTION ClassDB.getStudentActivitySummaryAnon(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getStudentActivitySummaryAnon(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getStudentActivitySummaryAnon(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -230,7 +231,8 @@ CREATE OR REPLACE VIEW ClassDB.StudentActivitySummaryAnon AS
 
 ALTER VIEW ClassDB.StudentActivitySummaryAnon OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentActivitySummaryAnon FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentActivitySummaryAnon TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentActivitySummaryAnon 
+      TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -294,7 +296,7 @@ ALTER FUNCTION ClassDB.getUserDDLActivity(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getUserDDLActivity(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getUserDDLActivity(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -354,7 +356,7 @@ ALTER FUNCTION ClassDB.getUserConnectionActivity(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getUserConnectionActivity(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getUserConnectionActivity(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -418,7 +420,7 @@ $$ LANGUAGE sql
 ALTER FUNCTION ClassDB.getUserActivity(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.getUserActivity(ClassDB.IDNameDomain) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getUserActivity(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -443,7 +445,7 @@ $$ LANGUAGE sql
 ALTER FUNCTION ClassDB.getStudentActivity(ClassDB.IDNameDomain) OWNER TO ClassDB;
 REVOKE ALL ON FUNCTION ClassDB.getStudentActivity(ClassDB.IDNameDomain) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getStudentActivity(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -456,7 +458,7 @@ CREATE OR REPLACE VIEW ClassDB.StudentActivity AS
 
 ALTER VIEW ClassDB.StudentActivity OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentActivity FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentActivity TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentActivity TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -482,7 +484,7 @@ ALTER FUNCTION ClassDB.getStudentActivityAnon(ClassDB.IDNameDomain)
 REVOKE ALL ON FUNCTION ClassDB.getStudentActivityAnon(ClassDB.IDNameDomain)
    FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION ClassDB.getStudentActivityAnon(ClassDB.IDNameDomain)
-   TO ClassDB_Instructor;
+   TO ClassDB_Admin, ClassDB_Instructor;
 
 
 
@@ -495,7 +497,7 @@ CREATE OR REPLACE VIEW ClassDB.StudentActivityAnon AS
 
 ALTER VIEW ClassDB.StudentActivityAnon OWNER TO ClassDB;
 REVOKE ALL PRIVILEGES ON ClassDB.StudentActivityAnon FROM PUBLIC;
-GRANT SELECT ON ClassDB.StudentActivityAnon TO ClassDB_Instructor;
+GRANT SELECT ON ClassDB.StudentActivityAnon TO ClassDB_Admin, ClassDB_Instructor;
 
 
 

--- a/src/server/core/initializeServerCore.sql
+++ b/src/server/core/initializeServerCore.sql
@@ -83,8 +83,10 @@ BEGIN
    PERFORM pg_temp.createGroupRole('classdb_instructor');
    PERFORM pg_temp.createGroupRole('classdb_dbmanager');
    PERFORM pg_temp.createGroupRole('classdb_team');
+   PERFORM pg_temp.createGroupRole('classdb_admin');
 
-   GRANT ClassDB_Student, ClassDB_Instructor, ClassDB_DBManager, ClassDB_Team
+   GRANT ClassDB_Student, ClassDB_Instructor, ClassDB_DBManager, ClassDB_Team,
+         ClassDB_Admin
    TO ClassDB;
 END
 $$;

--- a/src/server/removeAllFromServer.sql
+++ b/src/server/removeAllFromServer.sql
@@ -51,6 +51,7 @@ DROP ROLE IF EXISTS ClassDB_Instructor;
 DROP ROLE IF EXISTS ClassDB_DBManager;
 DROP ROLE IF EXISTS ClassDB_Student;
 DROP ROLE IF EXISTS ClassDB_Team;
+DROP ROLE IF EXISTS ClassDB_Admin;
 DROP ROLE IF EXISTS ClassDB;
 
 RESET client_min_messages;

--- a/tests/privileges/0_setup.sql
+++ b/tests/privileges/0_setup.sql
@@ -14,7 +14,7 @@
 START TRANSACTION;
 
 
---Create Instructor, Student, and DBManager to login for testing purposes.
+--Create Instructor, Student, DBManager, Admin to login for testing purposes.
 -- The password for these users will be the same as their username
 SELECT ClassDB.createInstructor('ptins0', 'Instructor 0');
 SELECT ClassDB.createInstructor('ptins1', 'Instructor 1');
@@ -27,6 +27,8 @@ SELECT ClassDB.createDBManager('ptdbm1', 'DB Manager 1');
 
 --Create team for testing access to team resources
 SELECT ClassDB.createTeam('ptTeam0', 'Team 0');
+SELECT ClassDB.AddToTeam('ptstu0','ptTeam0');
 
+CREATE USER ptadmin0 IN ROLE classdb_admin PASSWORD 'ptadmin0';
 
 COMMIT;

--- a/tests/privileges/10_cleanup.sql
+++ b/tests/privileges/10_cleanup.sql
@@ -1,4 +1,4 @@
---8_cleanup.sql - ClassDB
+--10_cleanup.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)
@@ -18,3 +18,6 @@ SELECT ClassDB.dropStudent('ptstu1', TRUE, TRUE, 'drop_c');
 SELECT ClassDB.dropDBManager('ptdbm0', TRUE, TRUE, 'drop_c');
 SELECT ClassDB.dropDBManager('ptdbm1', TRUE, TRUE, 'drop_c');
 SELECT Classdb.dropTeam('ptteam0', TRUE, TRUE, 'drop_c');
+
+DROP OWNED BY ptadmin0;
+DROP ROLE ptadmin0;

--- a/tests/privileges/3_dbmanagerPass.sql
+++ b/tests/privileges/3_dbmanagerPass.sql
@@ -15,36 +15,8 @@ START TRANSACTION;
 
 --Execute appropriate ClassDB functions (these tests do not verify correctness
 -- of each function)
-SELECT ClassDB.createStudent('teststu_pt', 'testname');
-SELECT ClassDB.resetPassword('teststu_pt');
 SELECT ClassDB.listUserConnections('teststu_pt');
 SELECT ClassDB.killUserConnections('teststu_pt');
-SELECT ClassDB.createTeam('testteam_pt');
-SELECT ClassDB.addToTeam('teststu_pt', 'testteam_pt');
-SELECT ClassDB.removeFromTeam('teststu_pt', 'testteam_pt');
-SELECT ClassDB.revokeTeam('testteam_pt');
-SET LOCAL client_min_messages TO WARNING;
-SELECT ClassDB.dropTeam('testteam_pt', TRUE, TRUE, 'drop_c');
-RESET client_min_messages;
-SELECT ClassDB.revokeStudent('teststu_pt');
-SET LOCAL client_min_messages TO WARNING;
-SELECT ClassDB.dropStudent('teststu_pt', TRUE, TRUE, 'drop_c');
-RESET client_min_messages;
---ClassDB.dropAllStudents is not being tested here because it would drop the
--- test students that will later be used to connect to the DB
---SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
-
-SELECT ClassDB.createInstructor('testins_pt', 'testname');
-SELECT ClassDB.revokeInstructor('testins_pt');
-SET LOCAL client_min_messages TO WARNING;
-SELECT ClassDB.dropInstructor('testins_pt', TRUE, TRUE, 'drop_c');
-RESET client_min_messages;
-
-SELECT ClassDB.createDBManager('testman_pt', 'noname');
-SELECT ClassDB.revokeDBManager('testman_pt');
-SET LOCAL client_min_messages TO WARNING;
-SELECT ClassDB.dropDBManager('testman_pt', TRUE, TRUE, 'drop_c');
-RESET client_min_messages;
 
 SELECT ClassDB.importConnectionLog();
 
@@ -88,16 +60,6 @@ SELECT * FROM public.myActivitySummary;
 SELECT * FROM public.MyDDLActivity;
 SELECT * FROM public.MyConnectionActivity;
 SELECT * FROM public.myActivity;
-
-
---Update FullName and ExtraInfo in RoleBase table
-SELECT ClassDB.createStudent('updateInfoTest', 'Temp name', NULL, 'Temp info');
-
-UPDATE ClassDB.RoleBase
-SET FullName = 'Updated name', ExtraInfo = 'Updated info'
-WHERE roleName = 'updateInfoTest';
-
-SELECT ClassDB.dropStudent('updateInfoTest', TRUE, TRUE, 'drop_c');
 
 
 --Read on tables in public schema created by Instructor (should return 1 row)

--- a/tests/privileges/5_adminPass.sql
+++ b/tests/privileges/5_adminPass.sql
@@ -1,4 +1,4 @@
---1_instructorPass.sql - ClassDB
+--5_adminPass.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)
@@ -15,35 +15,38 @@ START TRANSACTION;
 
 --Execute appropriate ClassDB functions (these tests do not verify correctness
 -- of each function)
+SELECT ClassDB.createStudent('teststu_pt', 'testname');
+SELECT ClassDB.resetPassword('teststu_pt');
 SELECT ClassDB.listUserConnections('teststu_pt');
 SELECT ClassDB.killUserConnections('teststu_pt');
+SELECT ClassDB.createTeam('testteam_pt');
+SELECT ClassDB.addToTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.removeFromTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.revokeTeam('testteam_pt');
+SET LOCAL client_min_messages TO WARNING;
+SELECT ClassDB.dropTeam('testteam_pt', TRUE, TRUE, 'drop_c');
+RESET client_min_messages;
+SELECT ClassDB.revokeStudent('teststu_pt');
+SET LOCAL client_min_messages TO WARNING;
+SELECT ClassDB.dropStudent('teststu_pt', TRUE, TRUE, 'drop_c');
+RESET client_min_messages;
+--ClassDB.dropAllStudents is not being tested here because it would drop the
+-- test students that will later be used to connect to the DB
+--SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
 
+SELECT ClassDB.createInstructor('testins_pt', 'testname');
+SELECT ClassDB.revokeInstructor('testins_pt');
+SET LOCAL client_min_messages TO WARNING;
+SELECT ClassDB.dropInstructor('testins_pt', TRUE, TRUE, 'drop_c');
+RESET client_min_messages;
+
+SELECT ClassDB.createDBManager('testman_pt', 'noname');
+SELECT ClassDB.revokeDBManager('testman_pt');
+SET LOCAL client_min_messages TO WARNING;
+SELECT ClassDB.dropDBManager('testman_pt', TRUE, TRUE, 'drop_c');
+RESET client_min_messages;
 
 SELECT ClassDB.importConnectionLog();
-
-
---CRUD on tables created by the instructor. This table should be placed in their
--- own schema and be accessed without needing to be fully schema qualified
---Create without schema qualification
-CREATE TABLE Test
-(
-   Col1 VARCHAR(10)
-);
-
---Insert with schema qualification - ensures test table was created in the
--- ptins0 schema
-INSERT INTO ptins0.Test VALUES ('hello');
-
---Select
-SELECT * FROM Test;
-
---Update
-UPDATE Test
-SET Col1 = 'goodbye';
-
---Delete
-DELETE FROM Test;
-DROP TABLE Test;
 
 
 --CRUD on public schema
@@ -96,21 +99,35 @@ SELECT * FROM public.MyConnectionActivity;
 SELECT * FROM public.myActivity;
 
 
+
+--Update FullName and ExtraInfo in RoleBase table
+SELECT ClassDB.createStudent('updateInfoTest', 'Temp name', NULL, 'Temp info');
+
+UPDATE ClassDB.RoleBase
+SET FullName = 'Updated name', ExtraInfo = 'Updated info'
+WHERE roleName = 'updateInfoTest';
+
+SELECT ClassDB.dropStudent('updateInfoTest', TRUE, TRUE, 'drop_c');
+
+
 --Create table in public schema to test read privileges for all users
-CREATE TABLE public.TestInsPublic
+CREATE TABLE public.TestAdminPublic
 (
    Col1 VARCHAR(20)
 );
 
-INSERT INTO public.testInsPublic VALUES ('Read by: anyone');
+INSERT INTO public.testAdminPublic VALUES ('Read by: anyone');
 
 --Create table in $user schema to test non-access for other roles
-CREATE TABLE TestInsUsr
+CREATE TABLE TestAdminUsr
 (
    col1 VARCHAR(20)
 );
 
-INSERT INTO testInsUsr VALUES('Read by: ptins0');
+INSERT INTO testAdminUsr VALUES('Read by: ptins0');
+
+--Add test student 0 to team 0
+SELECT ClassDB.addToTeam('ptstu0', 'ptteam0');
 
 
 COMMIT;

--- a/tests/privileges/6_instructorFail.sql
+++ b/tests/privileges/6_instructorFail.sql
@@ -1,4 +1,4 @@
---5_instructorFail.sql - ClassDB
+--6_instructorFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)
@@ -10,8 +10,31 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
+--Instructor should not be able to manage roles
+SELECT ClassDB.createStudent('teststu_pt', 'testname');
+SELECT ClassDB.resetPassword('teststu_pt');
+SELECT ClassDB.createTeam('testteam_pt');
+SELECT ClassDB.addToTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.removeFromTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.revokeTeam('testteam_pt');
+SELECT ClassDB.dropTeam('testteam_pt', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.revokeStudent('teststu_pt');
+SELECT ClassDB.dropStudent('teststu_pt', TRUE, TRUE, 'drop_c');
+--ClassDB.dropAllStudents is not being tested here because it would drop the
+-- test students that will later be used to connect to the DB
+--SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
 
---Not insert or delete from RoleBase table, or update unallowed columns
+SELECT ClassDB.createInstructor('testins_pt', 'testname');
+SELECT ClassDB.revokeInstructor('testins_pt');
+SELECT ClassDB.dropInstructor('testins_pt', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.createDBManager('testman_pt', 'noname');
+SELECT ClassDB.revokeDBManager('testman_pt');
+SELECT ClassDB.dropDBManager('testman_pt', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.addToTeam('ptstu0', 'ptteam0');
+
+
+
+--Not insert, delete or update from RoleBase table
 INSERT INTO ClassDB.RoleBase VALUES('testRole', 'Test name', FALSE,
                                     'Test schema', 'Test info');
 
@@ -29,6 +52,10 @@ WHERE RoleName = 'ptstu0';
 UPDATE ClassDB.RoleBase
 SET SchemaName = 'diffSchema'
 WHERE RoleName = 'ptstu0';
+
+UPDATE ClassDB.RoleBase
+SET FullName = 'Updated name', ExtraInfo = 'Updated info'
+WHERE roleName = 'ptstu0';
 
 
 --Not insert, update, or delete from DDLActivity and ConnectionActivity tables

--- a/tests/privileges/7_studentFail.sql
+++ b/tests/privileges/7_studentFail.sql
@@ -1,4 +1,4 @@
---6_studentFail.sql - ClassDB
+--7_studentFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)

--- a/tests/privileges/8_dbmanagerFail.sql
+++ b/tests/privileges/8_dbmanagerFail.sql
@@ -1,4 +1,4 @@
---7_dbmanagerFail.sql - ClassDB
+--8_dbmanagerFail.sql - ClassDB
 
 --Andrew Figueroa, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL)
@@ -10,6 +10,27 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
+
+--DB Manager should not be able to manage roles
+SELECT ClassDB.createStudent('teststu_pt', 'testname');
+SELECT ClassDB.resetPassword('teststu_pt');
+SELECT ClassDB.createTeam('testteam_pt');
+SELECT ClassDB.addToTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.removeFromTeam('teststu_pt', 'testteam_pt');
+SELECT ClassDB.revokeTeam('testteam_pt');
+SELECT ClassDB.dropTeam('testteam_pt', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.revokeStudent('teststu_pt');
+SELECT ClassDB.dropStudent('teststu_pt', TRUE, TRUE, 'drop_c');
+--ClassDB.dropAllStudents is not being tested here because it would drop the
+-- test students that will later be used to connect to the DB
+--SELECT ClassDB.dropAllStudents(TRUE, TRUE, 'drop_c');
+
+SELECT ClassDB.createInstructor('testins_pt', 'testname');
+SELECT ClassDB.revokeInstructor('testins_pt');
+SELECT ClassDB.dropInstructor('testins_pt', TRUE, TRUE, 'drop_c');
+SELECT ClassDB.createDBManager('testman_pt', 'noname');
+SELECT ClassDB.revokeDBManager('testman_pt');
+SELECT ClassDB.dropDBManager('testman_pt', TRUE, TRUE, 'drop_c');
 
 --Not insert or delete from RoleBase table, or update unallowed columns
 INSERT INTO ClassDB.RoleBase VALUES('testRole', 'Test name', FALSE,
@@ -30,6 +51,10 @@ WHERE RoleName = 'ptstu0';
 UPDATE ClassDB.RoleBase
 SET SchemaName = 'diffSchema'
 WHERE RoleName = 'ptstu0';
+
+UPDATE ClassDB.RoleBase
+SET FullName = 'Updated name', ExtraInfo = 'Updated info'
+WHERE roleName = 'ptstu0';
 
 
 --Not insert, update, or delete from DDLActivity and ConnectionActivity tables

--- a/tests/privileges/9_adminFail.sql
+++ b/tests/privileges/9_adminFail.sql
@@ -1,0 +1,183 @@
+--9_instructorFail.sql - ClassDB
+
+--Andrew Figueroa, Steven Rollo, Sean Murthy, Kevin Kelly
+--Data Science & Systems Lab (DASSL)
+--https://dassl.github.io/
+
+--(C) 2017- DASSL. ALL RIGHTS RESERVED.
+--Licensed to others under CC 4.0 BY-SA-NC
+--https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+--PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+
+--Not insert or delete from RoleBase table, or update unallowed columns
+INSERT INTO ClassDB.RoleBase VALUES('testRole', 'Test name', FALSE,
+                                    'Test schema', 'Test info');
+
+DELETE FROM ClassDB.RoleBase
+WHERE RoleName = 'ptstu0';
+
+UPDATE ClassDB.RoleBase
+SET RoleName = 'diffName'
+WHERE RoleName = 'ptstu0';
+
+UPDATE ClassDB.RoleBase
+SET IsTeam = TRUE
+WHERE RoleName = 'ptstu0';
+
+UPDATE ClassDB.RoleBase
+SET SchemaName = 'diffSchema'
+WHERE RoleName = 'ptstu0';
+
+
+--Not insert, update, or delete from DDLActivity and ConnectionActivity tables
+INSERT INTO ClassDB.DDLActivity VALUES ('ptstu0', '2000-01-01 00:00',
+                                        'CREATE TABLE', 'ptstu0.myTable');
+
+UPDATE ClassDB.DDLActivity
+SET DDLOperation = 'DROP TABLE'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.DDLActivity
+WHERE UserName = 'ptstu0';
+
+INSERT INTO ClassDB.ConnectionActivity VALUES ('ptsu0', '2000-01-01 00:00');
+
+UPDATE ClassDB.ConnectionActivity
+SET ActivityAtUTC = '1999-12-31 00:00'
+WHERE UserName = 'ptstu0';
+
+DELETE FROM ClassDB.ConnectionActivity
+WHERE UserNAme = 'ptstu0';
+
+
+--Not read other instructor or DB manager tables
+SELECT * FROM ptins0.testInsUsr;
+SELECT * FROM ptdbm0.testDbmUsr;
+
+
+--Not execute internal functions
+SELECT ClassDB.createRole('testrole', 'Test name', FALSE);
+SELECT ClassDB.revokeClassDBRole('ptstu0', 'classdb_student');
+SELECT ClassDB.dropRole('ptstu0');
+SELECT ClassDB.logDDLActivity();
+SELECT ClassDB.rejectOperation();
+
+--Not drop ClassDB tables and views
+DROP TABLE ClassDB.DDLActivity;
+DROP TABLE ClassDB.RoleBase;
+DROP VIEW public.MyActivity;
+DROP VIEW ClassDB.StudentActivityAnon;
+DROP VIEW ClassDB.StudentActivity;
+DROP VIEW public.MyConnectionActivity;
+DROP VIEW public.MyDDLActivity;
+DROP VIEW ClassDB.User;
+DROP VIEW ClassDB.Instructor;
+DROP VIEW ClassDB.Student;
+DROP VIEW ClassDB.DBManager;
+DROP VIEW ClassDB.StudentTable;
+DROP VIEW ClassDB.StudentTableCount;
+DROP VIEW ClassDB.StudentActivitySummary;
+DROP VIEW ClassDB.StudentActivitySummaryAnon;
+
+
+--Not drop ClassDB functions (also covers ALTER and REPLACE)
+DROP FUNCTION IF EXISTS classdb.cancreatedatabase(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.canlogin(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.changetimezone(TIMESTAMP, VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createdbmanager(ClassDB.IDNameDomain, VARCHAR,
+                                                ClassDB.IDNameDomain,VARCHAR,
+                                                BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createinstructor(ClassDB.IDNameDomain, VARCHAR,
+                                                 ClassDB.IDNameDomain,VARCHAR,
+                                                 BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createrole(ClassDB.IDNameDomain, VARCHAR,
+                                           BOOLEAN, ClassDB.IDNameDomain,
+                                           VARCHAR, BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS classdb.createstudent(ClassDB.IDNameDomain, VARCHAR,
+                                              ClassDB.IDNameDomain,VARCHAR,
+                                              BOOLEAN, BOOLEAN, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR, VARCHAR);
+DROP FUNCTION IF EXISTS public.describe(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.disableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.dropallstudents(BOOLEAN, BOOLEAN, VARCHAR,
+                                                ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropdbmanager(ClassDB.IDNameDomain, BOOLEAN,
+                                              BOOLEAN, VARCHAR,
+                                              ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropinstructor(ClassDB.IDNameDomain,BOOLEAN,
+                                               BOOLEAN, VARCHAR,
+                                               ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.droprole(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN,
+                                         VARCHAR, ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropstudent(ClassDB.IDNameDomain, BOOLEAN,
+                                            BOOLEAN, VARCHAR,
+                                            ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.enableddlactivitylogging();
+DROP FUNCTION IF EXISTS classdb.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.foldpgid(VARCHAR);
+DROP FUNCTION IF EXISTS public.getmyactivity();
+DROP FUNCTION IF EXISTS public.getmyactivitysummary();
+DROP FUNCTION IF EXISTS public.getmyconnectionactivity();
+DROP FUNCTION IF EXISTS public.getmyddlactivity();
+DROP FUNCTION IF EXISTS classdb.getschemaname(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getschemaownername(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuseractivitysummary(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserconnectionactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.getuserddlactivity(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hasclassdbrole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.hascreaterole(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.importconnectionlog(DATE);
+DROP FUNCTION IF EXISTS classdb.isclassdbrolename(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isdbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.ismember(ClassDB.IDNameDomain,
+                                          ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isroleknown(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isserverroledefined(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isstudent(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.issuperuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isteam(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isuser(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.killconnection(INT4);
+DROP FUNCTION IF EXISTS classdb.killuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listorphanobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.listownedobjects(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS public.listtables(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.listuserconnections(VARCHAR);
+DROP FUNCTION IF EXISTS classdb.logddlactivity();
+DROP FUNCTION IF EXISTS classdb.rejectoperation();
+DROP FUNCTION IF EXISTS classdb.resetpassword(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeclassdbrole(ClassDB.IDNameDomain,
+                                                   ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokedbmanager(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokeinstructor(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.revokestudent(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.createteam(ClassDB.IDNameDomain,
+                                           VARCHAR, ClassDB.IDNameDomain,
+                                           VARCHAR, BOOLEAN, BOOLEAN);
+DROP FUNCTION IF EXISTS classdb.revoketeam(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropteam(ClassDB.IDNameDomain, BOOLEAN, BOOLEAN,
+                                         VARCHAR, ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.dropallteams(BOOLEAN, BOOLEAN, VARCHAR,
+                                             ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isteammember(ClassDB.IDNameDomain,
+                                             ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.addtoteam(ClassDB.IDNameDomain,
+                                          ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.removefromteam(ClassDB.IDNameDomain,
+                                               ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.removeallfromteam(ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.reassignobjectownership(VARCHAR, VARCHAR,
+                                                        ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.reassignownedinschema(ClassDB.IDNameDomain,
+                                                      ClassDB.IDNameDomain,
+                                                      ClassDB.IDNameDomain);
+DROP FUNCTION IF EXISTS classdb.isconnectionloggingenabled();
+DROP FUNCTION IF EXISTS classdb.isloggingcollectorenabled();
+DROP FUNCTION IF EXISTS classdb.handledropschemaddlstart();
+DROP FUNCTION IF EXISTS classdb.disallowschemadrop();
+DROP FUNCTION IF EXISTS classdb.allowschemadrop();
+DROP FUNCTION IF EXISTS classdb.isschemadropallowed();

--- a/tests/privileges/runAllPrivilegeTests.psql
+++ b/tests/privileges/runAllPrivilegeTests.psql
@@ -46,19 +46,30 @@
 \connect - ptins1
 \ir 4_instructorPass2.sql
 
+\setenv PGPASSWORD ptadmin0
+\connect - ptadmin0
+\ir 5_adminPass.sql
+
 \echo 'README: If any previous test resulted in a warning, error, or exception, then privilege tests have failed'
 \echo 'All of the following tests should result in errors'
 \prompt 'Press enter to continue...' unusedInputVariable
 
-\ir 5_instructorFail.sql
+
+\setenv PGPASSWORD ptins1
+\connect - ptins1
+\ir 6_instructorFail.sql
 
 \setenv PGPASSWORD ptstu1
 \connect - ptstu1
-\ir 6_studentFail.sql
+\ir 7_studentFail.sql
 
 \setenv PGPASSWORD ptdbm1
 \connect - ptdbm1
-\ir 7_dbmanagerFail.sql
+\ir 8_dbmanagerFail.sql
+
+\setenv PGPASSWORD ptadmin0
+\connect - ptadmin0
+\ir 9_adminFail.sql
 
 \echo 'Initiating cleanup'
 \prompt 'Press enter to continue...' unusedInputVariable
@@ -66,4 +77,4 @@
 --Reset stored password to allow user to log in with original role
 \setenv PGPASSWORD
 \connect - :POSTGRES_USER
-\ir 8_cleanup.sql
+\ir 10_cleanup.sql

--- a/tests/testClassDBRolesMgmt.sql
+++ b/tests/testClassDBRolesMgmt.sql
@@ -722,9 +722,9 @@ BEGIN
    PERFORM ClassDB.createDBManager('testStuDBM0', 'Test student/DB manager 0');
    RESET client_min_messages;
 
-   --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
-   SET SESSION AUTHORIZATION tempDBM0;
+   --Create Admin to handle default object disposition
+   CREATE USER temp_admin IN ROLE classdb_admin;
+   SET SESSION AUTHORIZATION temp_admin;
 
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
@@ -741,7 +741,7 @@ BEGIN
    DROP OWNED BY testStu2;
    DROP ROLE testStu2;
 
-   SET SESSION AUTHORIZATION tempDBM0;
+   SET SESSION AUTHORIZATION temp_admin;
    PERFORM ClassDB.dropStudent('testStu2');
 
    --Drop server role and owned objects for fourth student
@@ -783,19 +783,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testStu1') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testStu4') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testStuDBM0') = 'tempdbm0')
+   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testStu1') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testStu4') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testStuDBM0') = 'temp_admin')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP OWNED BY tempDBM0;
-   DROP ROLE testStu0, testStu4, testStuDBM0, tempDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('teststudbm0', 'tempdbm0');
+   DROP OWNED BY temp_admin;
+   DROP ROLE testStu0, testStu4, testStuDBM0, temp_admin;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('teststudbm0', 'temp_admin');
 
    RETURN 'PASS';
 END;
@@ -823,9 +823,9 @@ BEGIN
    PERFORM ClassDB.createDBManager('testInsDBM0', 'Test instructor/DB manager 0');
    RESET client_min_messages;
 
-   --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
-   SET SESSION AUTHORIZATION tempDBM0;
+   --Create Admin to handle default object disposition
+   CREATE USER temp_admin IN ROLE classdb_admin;
+   SET SESSION AUTHORIZATION temp_admin;
 
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
@@ -842,7 +842,7 @@ BEGIN
    DROP OWNED BY testIns2;
    DROP ROLE testIns2;
 
-   SET SESSION AUTHORIZATION tempDBM0;
+   SET SESSION AUTHORIZATION temp_admin;
    PERFORM ClassDB.dropInstructor('testIns2');
 
    --Drop server role and owned objects for fourth instructor
@@ -884,19 +884,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testIns0') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testIns1') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testIns4') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testInsDBM0') = 'tempdbm0')
+   IF NOT(ClassDB.getSchemaOwnerName('testIns0') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testIns1') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testIns4') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testInsDBM0') = 'temp_admin')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP OWNED BY tempDBM0;
-   DROP ROLE testIns0, testIns4, testInsDBM0, tempDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testinsdbm0', 'tempdbm0');
+   DROP OWNED BY temp_admin;
+   DROP ROLE testIns0, testIns4, testInsDBM0, temp_admin;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testinsdbm0', 'temp_admin');
 
    RETURN 'PASS';
 END;
@@ -924,9 +924,9 @@ BEGIN
    PERFORM ClassDB.createStudent('testDBMStu0', 'Test DB manager/Student 0');
    RESET client_min_messages;
 
-   --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
-   SET SESSION AUTHORIZATION tempDBM0;
+   --Create Admin to handle default object disposition
+   CREATE USER temp_admin IN ROLE classdb_admin;
+   SET SESSION AUTHORIZATION temp_admin;
 
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
@@ -943,7 +943,7 @@ BEGIN
    DROP OWNED BY testDBM2;
    DROP ROLE testDBM2;
 
-   SET SESSION AUTHORIZATION tempDBM0;
+   SET SESSION AUTHORIZATION temp_admin;
    PERFORM ClassDB.dropDBManager('testDBM2');
 
    --Drop server role and owned objects for fourth DB manager
@@ -985,19 +985,19 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testDBM0') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testDBM1') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testDBM4') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testSchema') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testDBMStu0') = 'tempdbm0')
+   IF NOT(ClassDB.getSchemaOwnerName('testDBM0') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testDBM1') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testDBM4') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testSchema') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testDBMStu0') = 'temp_admin')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
 
    --Cleanup
-   DROP OWNED BY tempDBM0;
-   DROP ROLE testDBM0, testDBM4, testDBMStu0, tempDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testdbmstu0', 'tempdbm0');
+   DROP OWNED BY temp_admin;
+   DROP ROLE testDBM0, testDBM4, testDBMStu0, temp_admin;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName IN ('testdbmstu0', 'temp_admin');
 
    RETURN 'PASS';
 END;
@@ -1017,9 +1017,9 @@ BEGIN
    PERFORM ClassDB.createTeam('team4_dropTeam', 'Test team 4', NULL, 'Info');
    CREATE SCHEMA testSchema AUTHORIZATION team4_dropTeam;
    
-   --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('DBM0_dropTeam', 'Temporary DB manager 0');  
-   SET SESSION AUTHORIZATION DBM0_dropTeam;
+   --Create Admin to handle default object disposition
+   CREATE USER Admin0_dropTeam IN ROLE classdb_admin;
+   SET SESSION AUTHORIZATION Admin0_dropTeam;
    
    --Suppress NOTICEs about ownership reassignment
    SET SESSION client_min_messages TO WARNING;
@@ -1036,7 +1036,7 @@ BEGIN
    DROP OWNED BY team2_dropTeam;
    DROP ROLE team2_dropTeam;
 
-   SET SESSION AUTHORIZATION DBM0_dropTeam;
+   SET SESSION AUTHORIZATION Admin0_dropTeam;
    PERFORM ClassDB.dropTeam('team2_dropTeam');
 
    --Drop server role and owned objects for fourth team
@@ -1073,10 +1073,10 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('team0_dropTeam') = ClassDB.foldPgID('DBM0_dropTeam')
-      AND ClassDB.getSchemaOwnerName('team1_dropTeam') = ClassDB.foldPgID('DBM0_dropTeam')
-      AND ClassDB.getSchemaOwnerName('team4_dropTeam') = ClassDB.foldPgID('DBM0_dropTeam')
-      AND ClassDB.getSchemaOwnerName('testSchema') = ClassDB.foldPgID('DBM0_dropTeam'))
+   IF NOT(ClassDB.getSchemaOwnerName('team0_dropTeam') = ClassDB.foldPgID('Admin0_dropTeam')
+      AND ClassDB.getSchemaOwnerName('team1_dropTeam') = ClassDB.foldPgID('Admin0_dropTeam')
+      AND ClassDB.getSchemaOwnerName('team4_dropTeam') = ClassDB.foldPgID('Admin0_dropTeam')
+      AND ClassDB.getSchemaOwnerName('testSchema') = ClassDB.foldPgID('Admin0_dropTeam'))
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
@@ -1094,8 +1094,8 @@ BEGIN
    PERFORM ClassDB.createStudent('testStu1', 'Test student 1');
 
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('tempdbm0', 'Temporary DB manager 0');
-   SET SESSION AUTHORIZATION tempDBM0;
+   CREATE ROLE temp_admin IN ROLE classdb_admin;
+   SET SESSION AUTHORIZATION temp_admin;
 
    --Minimal drop
    PERFORM ClassDB.dropAllStudents();
@@ -1118,8 +1118,8 @@ BEGIN
    END IF;
 
    --Check for ownership of existing schemas
-   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'tempdbm0'
-      AND ClassDB.getSchemaOwnerName('testStu1') = 'tempdbm0')
+   IF NOT(ClassDB.getSchemaOwnerName('testStu0') = 'temp_admin'
+      AND ClassDB.getSchemaOwnerName('testStu1') = 'temp_admin')
    THEN
       RETURN 'FAIL: Code 3';
    END IF;
@@ -1150,9 +1150,9 @@ BEGIN
    END IF;
 
    --Cleanup
-   DROP OWNED BY tempDBM0;
-   DROP ROLE tempDBM0;
-   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'tempdbm0';
+   DROP OWNED BY temp_admin;
+   DROP ROLE temp_admin;
+   DELETE FROM ClassDB.RoleBase WHERE RoleName = 'temp_admin';
 
    RETURN 'PASS';
 END;
@@ -1167,8 +1167,8 @@ BEGIN
    PERFORM ClassDB.createTeam('team1_dropAllTeams', 'Test team 1');
    
    --Create DB manager to handle default object disposition
-   PERFORM ClassDB.createDBManager('DBM0_dropAllTeams', 'Temp DB manager 0');  
-   SET SESSION AUTHORIZATION DBM0_dropAllTeams;
+   CREATE USER Admin0_dropAllTeams IN ROLE classdb_admin;  
+   SET SESSION AUTHORIZATION Admin0_dropAllTeams;
 
    --Minimal drop, NOTICEs are silenced
    SET LOCAL client_min_messages TO WARNING;
@@ -1194,9 +1194,9 @@ BEGIN
 
    --Check for ownership of existing schemas
    IF NOT(ClassDB.getSchemaOwnerName('team0_dropAllTeams') 
-                                    = ClassDB.foldPgID('DBM0_dropAllTeams')
+                                    = ClassDB.foldPgID('Admin0_dropAllTeams')
       AND ClassDB.getSchemaOwnerName('team1_dropAllTeams') 
-                                    = ClassDB.foldPgID('DBM0_dropAllTeams'))
+                                    = ClassDB.foldPgID('Admin0_dropAllTeams'))
    THEN
       RETURN 'FAIL: Code 3';
    END IF;


### PR DESCRIPTION
This PR removes the ability for non-admin users to manage roles. However, in order to do this we still needed a non-superuser role that could run these role management functions. Otherwise, we will be forced to use the superuser which is not a good option. To fix this issue, I added a role `classdb_admin` that can now run these role management functions.

There is a lot of small changes I made so I organized this list to summarize what I changed in this PR to ensure correct functionality:

1) Removed `classdb_instructor` and `classdb_dbmanager` from usage on functions relating to role management.

2) Added a role `classdb_admin` that has usage on all functions `classdb_instructor` has plus the role management functions.

3) Updated `testClassDBRolesMgmt.sql` to work with these new additions. A `classdb_admin` role now handles object disposition compared to the `classdb_dbmanager` from before. This is because `classdb_dbmanager` no longer has sufficient privileges to preform this function.

4) Updated privilege tests to reflect the above changes to `classdb_instructor` and `classdb_dbmanager`. I also added two new files, which are more or less copies from the old `instructorPass.sql`  and `instructorFail.sql`  files since admin is nearly equivalent to the `classdb_instructor`  role from before this PR. 

While I believe the `classdb_admin` role is now functional enough to be implemented in this PR, I think the role needs to be expanded. For instance, we may want to make function `createAdmin(...)` in the future. However, this does not fit the scope of this PR. 