### PR TITLE
Add user access function

### DIFF
--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -65,9 +65,21 @@ BEGIN
 END
 $$;
 
+--Prevent users who are not instructors from modifying the public schema
+-- public schema contains objects and functions students can read
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+GRANT CREATE ON SCHEMA public TO ClassDB_Admin, ClassDB_Instructor;
 
---Grant appropriate privileges to different roles to the current database
-DO
+--Create a schema to hold app's admin info and assign privileges on that schema
+CREATE SCHEMA IF NOT EXISTS classdb AUTHORIZATION ClassDB;
+GRANT USAGE ON SCHEMA classdb 
+      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
+
+--Define a function to grant appropriate privileges to different roles to the 
+-- current database This is added so that it can be called again when ClassDB
+-- database is used as a template
+CREATE OR REPLACE FUNCTION ClassDB.AddUserAccess()
+RETURNS VOID AS
 $$
 DECLARE
    currentDB VARCHAR(128);
@@ -88,21 +100,26 @@ BEGIN
    EXECUTE format('GRANT CREATE ON DATABASE %I TO ClassDB, ClassDB_Admin, '
                   'ClassDB_Instructor, ClassDB_Student, ClassDB_DBManager'
                   , currentDB);
+END;
+$$ LANGUAGE plpgsql;
 
+
+ALTER FUNCTION ClassDB.AddUserAccess() OWNER TO ClassDB;
+
+REVOKE ALL ON FUNCTION ClassDB.AddUserAccess() FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION ClassDB.AddUserAccess()
+      TO ClassDB_Admin;
+
+
+--Execute this above function for when script is run for first time on template
+-- database
+DO
+$$
+BEGIN
+  PERFORM ClassDB.AddUserAccess();
 END
 $$;
-
-
-
---Prevent users who are not instructors from modifying the public schema
--- public schema contains objects and functions students can read
-REVOKE CREATE ON SCHEMA public FROM PUBLIC;
-GRANT CREATE ON SCHEMA public TO ClassDB_Admin, ClassDB_Instructor;
-
---Create a schema to hold app's admin info and assign privileges on that schema
-CREATE SCHEMA IF NOT EXISTS classdb AUTHORIZATION ClassDB;
-GRANT USAGE ON SCHEMA classdb 
-      TO ClassDB_Admin, ClassDB_Instructor, ClassDB_DBManager;
 
 
 COMMIT;


### PR DESCRIPTION
This PR modifies `initializeDBCore.sql` to so that setting access privileges for the database is on the function. This is done because the initial database ClassDB will be installed will be used as a template. However, when the template gets copied the objects within it remain intact but the database object loses it previous access privileges. This means we need to call a function such as `ClassDB.AddUserAccess()` to re-add the correct access privileges.