### PR TITLE
Grant Create on Schema public to classdb

### DIFF
--- a/src/db/core/initializeDBCore.sql
+++ b/src/db/core/initializeDBCore.sql
@@ -97,7 +97,7 @@ $$;
 --Prevent users who are not instructors from modifying the public schema
 -- public schema contains objects and functions students can read
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
-GRANT CREATE ON SCHEMA public TO ClassDB_Admin, ClassDB_Instructor;
+GRANT CREATE ON SCHEMA public TO ClassDB_Admin, ClassDB_Instructor, ClassDB;
 
 --Create a schema to hold app's admin info and assign privileges on that schema
 CREATE SCHEMA IF NOT EXISTS classdb AUTHORIZATION ClassDB;


### PR DESCRIPTION
Quick PR to grant role `classdb` create on schema public. We are doing this because it can cause issues from classdb creating schemas when creating users.